### PR TITLE
Leaf::onCanopyWaterBalance should not update sw_demand when DCaPST is being used

### DIFF
--- a/Model/Plant/Leaf/Leaf.cpp
+++ b/Model/Plant/Leaf/Leaf.cpp
@@ -119,7 +119,7 @@ void Leaf::onCanopyWaterBalance(protocol::CanopyWaterBalanceType& CWB)
 		}
 	}
 	else {
-		scienceAPI.warning("DCaPST cannot be used with an external soil water demand (e.g. MicroMet)!\nLeaf::onCanopyWaterBalance() did not update 'sw_demand'.");
+		scienceAPI.warning("DCaPST cannot be used with an external soil water demand (e.g. Micromet)!\nLeaf::onCanopyWaterBalance() did not update 'sw_demand'.");
 	}
 }
 

--- a/Model/Plant/Plant.vcxproj
+++ b/Model/Plant/Plant.vcxproj
@@ -15,12 +15,11 @@
     <RootNamespace>Plant</RootNamespace>
     <Keyword>Win32Proj</Keyword>
     <TargetFrameworkProfile>Client</TargetFrameworkProfile>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>

--- a/Model/Plant/Plant.vcxproj
+++ b/Model/Plant/Plant.vcxproj
@@ -15,11 +15,12 @@
     <RootNamespace>Plant</RootNamespace>
     <Keyword>Win32Proj</Keyword>
     <TargetFrameworkProfile>Client</TargetFrameworkProfile>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>


### PR DESCRIPTION
Resolves #1810 

@jbrider **DCaPST** cannot be used with Micromet as it replaces the sw_demand calculated by DCaPST with **PotentialEp** calculated by Micromet. I made the code bypass this procedure if DCaPST is being used, in which case a warning is issued, Alex informed me that he had the same problem with the Maize model (i.e. wrong sw_demand). So I thought maybe you want to have a look at this.

```
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
                      APSIM Warning Error
                      -------------------
     DCaPST cannot be used with an external soil water demand (e.g. Micromet)!
     Leaf::onCanopyWaterBalance() did not update 'sw_demand'.
     Component name: paddock.wheat
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
```

