### PR TITLE
Fix an import using lowercase imports

### DIFF
--- a/Model/Maize/BiomassCM.h
+++ b/Model/Maize/BiomassCM.h
@@ -4,7 +4,7 @@
 #define BiomassCMH
 
 #include "PlantComponents.h"
-#include "biomass.h"
+#include "Biomass.h"
 namespace Maize {
    //------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes https://github.com/APSIMInitiative/APSIMClassic/issues/1879 on Linux:

```
[Pass] Compile Maize [43sec]
```

`#include "biomass.h"` would work on Windows because file lookups are case insensitive, but that's not the case on Linux.