### PR TITLE
C#/VB components should be branded with rev # iff it is a number

### DIFF
--- a/Model/Build/VersionStamper.cs
+++ b/Model/Build/VersionStamper.cs
@@ -79,17 +79,13 @@ class VersionStamper
             // Write the VersionInfo.cs
             Out = new StreamWriter("VersionInfo.cs");
             Out.WriteLine("using System.Reflection;");
-            Out.WriteLine("[assembly: AssemblyFileVersion(\"" + Major.ToString() + "." +
-                                                                Minor.ToString() +
-																".0.0\")]");
+            Out.WriteLine(string.Format("[assembly: AssemblyFileVersion(\"{0}.{1}.{2}.{3}\")]", Major, Minor, int.TryParse(RevisionNumber, out _) ? RevisionNumber : "0", "0"));
             Out.Close();
 
             // Write the VersionInfo.vb
             Out = new StreamWriter("VersionInfo.vb");
             Out.WriteLine("Imports System.Reflection");
-            Out.WriteLine("<Assembly: AssemblyFileVersion(\"" + Major.ToString() + "." +
-                                                                Minor.ToString() +
-																".0.0\")>");
+            Out.WriteLine(string.Format("<Assembly: AssemblyFileVersion(\"{0}.{1}.{2}.{3}\")>", Major, Minor, int.TryParse(RevisionNumber, out _) ? RevisionNumber : "0", "0"));
             Out.Close();
 
             // Write the VersionInfo.cpp

--- a/Model/Build/VersionStamper.cs
+++ b/Model/Build/VersionStamper.cs
@@ -77,15 +77,16 @@ class VersionStamper
             Out.Close();
 
             // Write the VersionInfo.cs
+			int ignore;
             Out = new StreamWriter("VersionInfo.cs");
             Out.WriteLine("using System.Reflection;");
-            Out.WriteLine(string.Format("[assembly: AssemblyFileVersion(\"{0}.{1}.{2}.{3}\")]", Major, Minor, int.TryParse(RevisionNumber, out _) ? RevisionNumber : "0", "0"));
+            Out.WriteLine(string.Format("[assembly: AssemblyFileVersion(\"{0}.{1}.{2}.{3}\")]", Major, Minor, int.TryParse(RevisionNumber, out ignore) ? RevisionNumber : "0", "0"));
             Out.Close();
 
             // Write the VersionInfo.vb
             Out = new StreamWriter("VersionInfo.vb");
             Out.WriteLine("Imports System.Reflection");
-            Out.WriteLine(string.Format("<Assembly: AssemblyFileVersion(\"{0}.{1}.{2}.{3}\")>", Major, Minor, int.TryParse(RevisionNumber, out _) ? RevisionNumber : "0", "0"));
+            Out.WriteLine(string.Format("<Assembly: AssemblyFileVersion(\"{0}.{1}.{2}.{3}\")>", Major, Minor, int.TryParse(RevisionNumber, out ignore) ? RevisionNumber : "0", "0"));
             Out.Close();
 
             // Write the VersionInfo.cpp


### PR DESCRIPTION
Resolves #1853